### PR TITLE
fix: enable rollback on failure for DA & increase dsc helm timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ You need the following permissions to run this module:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_backup_recovery_instance"></a> [backup\_recovery\_instance](#module\_backup\_recovery\_instance) | terraform-ibm-modules/backup-recovery/ibm | v1.10.1 |
+| <a name="module_backup_recovery_instance"></a> [backup\_recovery\_instance](#module\_backup\_recovery\_instance) | terraform-ibm-modules/backup-recovery/ibm | v1.10.2 |
 | <a name="module_crn_parser"></a> [crn\_parser](#module\_crn\_parser) | terraform-ibm-modules/common-utilities/ibm//modules/crn-parser | 1.5.0 |
 | <a name="module_dsc_sg_rule"></a> [dsc\_sg\_rule](#module\_dsc\_sg\_rule) | terraform-ibm-modules/security-group/ibm | v2.9.0 |
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ You need the following permissions to run this module:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_backup_recovery_instance"></a> [backup\_recovery\_instance](#module\_backup\_recovery\_instance) | terraform-ibm-modules/backup-recovery/ibm | v1.10.1 |
+| <a name="module_backup_recovery_instance"></a> [backup\_recovery\_instance](#module\_backup\_recovery\_instance) | terraform-ibm-modules/backup-recovery/ibm | v1.10.2 |
 | <a name="module_crn_parser"></a> [crn\_parser](#module\_crn\_parser) | terraform-ibm-modules/common-utilities/ibm//modules/crn-parser | 1.5.0 |
 | <a name="module_dsc_sg_rule"></a> [dsc\_sg\_rule](#module\_dsc\_sg\_rule) | terraform-ibm-modules/security-group/ibm | v2.9.0 |
 
@@ -219,7 +219,7 @@ You need the following permissions to run this module:
 | <a name="input_connection_env_type"></a> [connection\_env\_type](#input\_connection\_env\_type) | Connection environment type to determine the required parameters for creating a new connection. Allowed values are 'kIksVpc', 'kRoksVpc', 'kRoksClassic', and 'kIksClassic'. | `string` | `"kIksVpc"` | no |
 | <a name="input_create_dsc_worker_pool"></a> [create\_dsc\_worker\_pool](#input\_create\_dsc\_worker\_pool) | Set to `true` to create a dedicated worker pool for the Data Source Connector in VPC clusters. If set to `false`, the connector will be deployed on existing worker nodes. | `bool` | `true` | no |
 | <a name="input_dsc_chart_uri"></a> [dsc\_chart\_uri](#input\_dsc\_chart\_uri) | The full OCI registry URI for the Data Source Connector Helm chart, including the digest. | `string` | `"oci://icr.io/ext/brs/brs-ds-connector-chart:7.2.18-release-20260226-49768040@sha256:99728a3146a7d8b2ae2f88300a6a89752488d3733e29118ee83a655959114541"` | no |
-| <a name="input_dsc_helm_timeout"></a> [dsc\_helm\_timeout](#input\_dsc\_helm\_timeout) | Timeout in seconds for the Data Source Connector Helm deployment. | `number` | `1500` | no |
+| <a name="input_dsc_helm_timeout"></a> [dsc\_helm\_timeout](#input\_dsc\_helm\_timeout) | Timeout in seconds for the Data Source Connector Helm deployment. | `number` | `3600` | no |
 | <a name="input_dsc_image_version"></a> [dsc\_image\_version](#input\_dsc\_image\_version) | Container image for the Data Source Connector. | `string` | `"icr.io/ext/brs/brs-ds-connector:7.2.18-release-20260226-49768040@sha256:99728a3146a7d8b2ae2f88300a6a89752488d3733e29118ee83a655959114541"` | no |
 | <a name="input_dsc_name"></a> [dsc\_name](#input\_dsc\_name) | Release name for the Data Source Connector Helm deployment. | `string` | `"dsc"` | no |
 | <a name="input_dsc_namespace"></a> [dsc\_namespace](#input\_dsc\_namespace) | The cluster namespace where the Data Source Connector will be installed. Will be created if it does not exist. | `string` | `"ibm-brs-data-source-connector"` | no |

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -236,6 +236,10 @@
               ]
             },
             {
+              "key": "rollback_on_failure",
+              "display_name": "Rollback On Failure"
+            },
+            {
               "key": "existing_brs_instance_crn",
               "display_name": "Backup Recovery Service Instance",
               "type": "string",

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "crn_parser" {
 
 module "backup_recovery_instance" {
   source                    = "terraform-ibm-modules/backup-recovery/ibm"
-  version                   = "v1.10.1"
+  version                   = "v1.10.2"
   region                    = local.brs_region
   resource_group_id         = var.cluster_resource_group_id
   ibmcloud_api_key          = var.ibmcloud_api_key

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -62,6 +62,7 @@ module "protect_cluster" {
   dsc_helm_timeout       = var.dsc_helm_timeout
   dsc_storage_class      = var.dsc_storage_class
   create_dsc_worker_pool = var.create_dsc_worker_pool
+  rollback_on_failure    = var.rollback_on_failure
   # --- Registration Settings ---
   registration_images = var.registration_images
   enable_auto_protect = var.enable_auto_protect

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -294,7 +294,7 @@ variable "dsc_replicas" {
 variable "dsc_helm_timeout" {
   description = "Timeout in seconds for the Data Source Connector Helm deployment."
   type        = number
-  default     = 1500
+  default     = 3600
   nullable    = false
 }
 
@@ -325,6 +325,11 @@ variable "dsc_registry" {
   type        = string
   default     = "icr.io"
   nullable    = false
+}
+variable "rollback_on_failure" {
+  description = "Flag to automatically rollback the helm chart on installation failure."
+  type        = bool
+  default     = true
 }
 variable "brs_connection_name" {
   type        = string

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -250,6 +250,8 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 			"module.protect_cluster.kubernetes_service_account_v1.brsagent",
 			"module.protect_cluster.time_rotating.token_rotation",
 			"module.protect_cluster.ibm_backup_recovery_connection_registration_token.registration_token",
+			"module.protect_cluster.terraform_data.wait_before_helm_destroy",
+			"module.protect_cluster.terraform_data.cleanup_brs_agent_resources",
 		},
 	}
 

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "dsc_replicas" {
 variable "dsc_helm_timeout" {
   description = "Timeout in seconds for the Data Source Connector Helm deployment."
   type        = number
-  default     = 1500
+  default     = 3600
   nullable    = false
 }
 


### PR DESCRIPTION
### Description

This PR introduces improvements to the Deployable Architecture (DA) configuration and Helm deployment reliability:

**Changes:**

1. **Enable Rollback on Failure for DA**: Added `rollback_on_failure` variable to the fully-configurable solution, allowing automatic rollback of Helm chart installations when they fail. This improves deployment reliability and prevents partial installations from remaining in the cluster.

2. **Increase DSC Helm Timeout**: Extended the Data Source Connector (DSC) Helm deployment timeout from 1500 seconds (25 minutes) to 3600 seconds (60 minutes). This change addresses timeout issues in environments with slower network connectivity or resource constraints during Helm chart installation.

3. **Update Backup Recovery Module Version**: Bumped the `terraform-ibm-modules/backup-recovery/ibm` module version from v1.10.1 to v1.10.2 to incorporate the latest fixes and improvements.

4. **Catalog Configuration Update**: Added the `rollback_on_failure` configuration option to `ibm_catalog.json` to expose this setting in the IBM Cloud Catalog UI for the fully-configurable flavor.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Increased Data Source Connector Helm deployment timeout from 25 to 60 minutes to address timeout issues in environments with slower provisioning or storage binding delays
- Added `rollback_on_failure` variable to fully-configurable solution for better deployment failure handling
- Updated backup-recovery module to v1.10.2

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
