### PR TITLE
fix: handle OCP source tree lookup for namespace IDs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -656,9 +656,33 @@ data "ibm_backup_recovery_protection_sources" "sources" {
 locals {
   # Flatten protection sources up to 3 levels deep to create a map of object names
   # (namespaces, PVCs, etc.) to IDs — scoped to THIS cluster's registered source only.
+  #
+  # The BRS Terraform provider exposes the kKubernetes source tree as:
+  #
+  #   protection_sources[N]          ← env envelope (no protection_source attr)
+  #     └── nodes[M]                 ← cluster node
+  #           IKS:  protection_source[0].id = cluster source_id  (L1 has it)
+  #           OCP:  NO protection_source attr at this level
+  #           └── nodes[K]           ← namespace / label nodes
+  #                 IKS:  protection_source[0].id = namespace object id
+  #                 OCP:  protection_source[0].id = namespace object id
+  #                       protection_source[0].parent_id = cluster source_id  ← key difference
+  #                 └── nodes[J]     ← PVC nodes
+  #
+  # IKS filter: keep the L1 node whose protection_source[0].id == source_id
+  # OCP filter: keep the L1 node that has at least one L2 child whose
+  #             protection_source[0].parent_id == source_id
+  #
+  # When source_id is not yet known (null) or not found in the tree (source
+  # discovery still in progress), the filter is skipped so all nodes are
+  # included — identical to pre-PR-74 behaviour, which avoids an empty
+  # all_flat_objects and prevents a spurious precondition failure.
 
-  # Pre-compute the set of all node-level source IDs present in the current API response.
-  all_known_source_ids = toset(flatten([
+  source_id_str = tostring(ibm_backup_recovery_source_registration.source_registration.source_id)
+
+  # IKS: source_id appears as protection_source[0].id on the L1 cluster node.
+  # Collect all such L1 IDs to cheaply detect whether we are in IKS mode.
+  all_known_l1_source_ids = toset(flatten([
     for env in(try(data.ibm_backup_recovery_protection_sources.sources.protection_sources, []) != null ? data.ibm_backup_recovery_protection_sources.sources.protection_sources : []) :
     [for node in(env.nodes != null ? env.nodes : []) :
       tostring(node.protection_source[0].id)
@@ -666,18 +690,43 @@ locals {
     ]
   ]))
 
+  # OCP: source_id appears as protection_source[0].parent_id on L2 namespace nodes.
+  # Collect all such parent_id values so we can detect OCP mode and find the right L1.
+  all_known_l2_parent_ids = toset(flatten([
+    for env in(try(data.ibm_backup_recovery_protection_sources.sources.protection_sources, []) != null ? data.ibm_backup_recovery_protection_sources.sources.protection_sources : []) :
+    [for node in(env.nodes != null ? env.nodes : []) :
+      [for child in(node.nodes != null ? node.nodes : []) :
+        tostring(try(child.protection_source[0].parent_id, ""))
+        if child.protection_source != null && length(child.protection_source) > 0 &&
+        try(child.protection_source[0].parent_id, null) != null
+      ]
+    ]
+  ]))
+
+  # Filter is active only when source_id is non-null and present in either set.
   filter_by_source_id = (
     ibm_backup_recovery_source_registration.source_registration.source_id != null &&
-    contains(local.all_known_source_ids, tostring(ibm_backup_recovery_source_registration.source_registration.source_id))
+    (
+      contains(local.all_known_l1_source_ids, local.source_id_str) ||
+      contains(local.all_known_l2_parent_ids, local.source_id_str)
+    )
   )
 
   all_env_nodes = flatten([
     for env in(try(data.ibm_backup_recovery_protection_sources.sources.protection_sources, []) != null ? data.ibm_backup_recovery_protection_sources.sources.protection_sources : []) :
     [for node in(env.nodes != null ? env.nodes : []) : node
       if !local.filter_by_source_id ||
+      # IKS: source_id is the L1 node's own protection_source[0].id
       (node.protection_source != null &&
         length(node.protection_source) > 0 &&
-      tostring(node.protection_source[0].id) == tostring(ibm_backup_recovery_source_registration.source_registration.source_id))
+      tostring(node.protection_source[0].id) == local.source_id_str) ||
+      # OCP: source_id appears as parent_id on one of this L1 node's L2 children
+      anytrue([
+        for child in(node.nodes != null ? node.nodes : []) :
+        (child.protection_source != null &&
+          length(child.protection_source) > 0 &&
+        tostring(try(child.protection_source[0].parent_id, "")) == local.source_id_str)
+      ])
     ]
   ])
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -74,8 +74,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
### Description

Fixes a regression introduced in PR #74 where the namespace-scoping filter worked correctly for IKS but silently did nothing for OCP/ROKS clusters in cross-cluster (`full_backup_recovery` + `recovery_type = "cross-cluster"`) deployments.

**Root cause:** PR #74 tried to scope the `object_name_to_id` namespace lookup to only the source cluster by checking whether the registered `source_id` appeared as `protection_source[0].id` on the L1 cluster node in the BRS protection sources tree. This assumption holds for IKS but not for OCP. For OCP/ROKS, the L1 cluster node does not carry the registered `source_id` in that field — the `source_id` only appears as `protection_source[0].parent_id` on the L2 namespace child nodes.

Because `source_id` was never found in `all_known_source_ids` for OCP, `filter_by_source_id` always evaluated to `false`, which meant the `!filter_by_source_id` bypass kept all clusters' namespaces unfiltered in `object_name_to_id`. When source and target clusters both had a namespace with the same name, the wrong (target cluster) namespace ID was resolved, causing the **target cluster's namespace to be backed up and restored to itself** — identical to a same-cluster scenario on the target — instead of backing up the source cluster's namespace and restoring it to the target.

**Fix:**
- Added `all_known_l2_parent_ids`: walks L2 namespace nodes and collects `protection_source[0].parent_id` values, which is where OCP stores the cluster `source_id`
- `filter_by_source_id` now activates for both IKS (L1 `id` match) and OCP (L2 `parent_id` match)
- `all_env_nodes` node selection adds a second OCP-specific path using `anytrue([...child.protection_source[0].parent_id == source_id...])` to find the correct L1 cluster node whose children reference the registered source
- The IKS path (`protection_source[0].id == source_id` at L1) is completely unchanged — no regression for IKS

Also bumps `github.com/go-git/go-git/v5` from `v5.19.1` to `v5.19.2` to resolve CVE-2026-71556 (HIGH) flagged by Trivy pre-commit scan.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This patch fixes a bug where OCP/ROKS cross-cluster backup incorrectly backed up a namespace from the **target** cluster instead of the source cluster when both clusters had a namespace with the same name. The root cause was an incomplete namespace-scoping filter introduced in PR #74 that only handled the IKS source tree structure. OCP uses a different BRS internal tree layout where the registered `source_id` is stored in `parent_id` on namespace nodes rather than `id` on the cluster node. Users running `deployment_mode = "full_backup_recovery"` with `recovery_type = "cross-cluster"` on OCP/ROKS clusters with overlapping namespace names should upgrade to this version. No changes are required to existing configurations — the fix is purely internal to the namespace ID resolution logic.


<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
