### PR TITLE
fix: move vpe and s2s out of root module.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -668,6 +668,9 @@ resource "terraform_data" "wait_for_dsc_node_ready" {
 resource "kubernetes_namespace_v1" "dsc_namespace" {
   metadata {
     name = var.dsc_namespace
+    labels = {
+      "velero.io/exclude-from-backup" = "true"
+    }
   }
 
   timeouts {

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -315,6 +315,66 @@ resource "kubernetes_storage_class_v1" "recovery_alias" {
   }
 
   depends_on = [data.ibm_container_cluster_config.target_cluster_config]
+data "ibm_is_security_group" "target_kube_vpeg_sg" {
+  count    = local.target_brs_vpe_active ? 1 : 0
+  provider = ibm.target_cluster
+  name     = "kube-vpegw-${local.target_resolved_vpc_id}"
+}
+
+# VPE Gateway for target cluster — routes DSC↔BRS traffic over IBM private backbone.
+# Same create-and-forget pattern as the source VPE above.
+module "target_brs_vpe" {
+  count   = local.target_brs_vpe_active ? 1 : 0
+  source  = "terraform-ibm-modules/vpe-gateway/ibm"
+  version = "5.4.0"
+  providers = {
+    ibm = ibm.target_cluster
+  }
+
+  region             = var.target_cluster_region
+  vpc_id             = local.target_resolved_vpc_id
+  vpc_name           = local.target_brs_vpe_name_resolved
+  resource_group_id  = var.target_cluster_resource_group_id
+  security_group_ids = [data.ibm_is_security_group.target_kube_vpeg_sg[0].id]
+  subnet_zone_list   = [for s in local.target_resolved_vpc_subnets : { name = s.name, id = s.id, zone = s.zone }]
+  service_endpoints  = var.brs_endpoint_type
+
+  cloud_service_by_crn = [{
+    crn      = module.protect_cluster.brs_instance_crn
+    vpe_name = local.target_brs_vpe_name_resolved
+  }]
+
+  resource_tags = var.resource_tags
+  access_tags   = var.access_tags
+
+  depends_on = [module.target_cluster_registration]
+}
+
+# Detach previously inline-managed target VPE resources from state.
+# The cloud objects are NOT destroyed — only removed from Terraform management.
+removed {
+  from = ibm_is_subnet_reserved_ip.target_brs_vpe_ip
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = ibm_is_virtual_endpoint_gateway.target_brs_vpe
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = ibm_is_virtual_endpoint_gateway_ip.target_brs_vpe_ip
+
+  lifecycle {
+    destroy = false
+  }
+
 }
 
 # Wait for target registration to propagate

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -257,6 +257,12 @@ module "target_cluster_registration" {
 # Recovery Storage Class Aliases (target cluster)
 ##############################################################################
 
+locals {
+  # A VPE is only ever built for a VPC target cluster.
+  target_is_vpc         = length(regexall("Vpc$", coalesce(var.target_connection_env_type, var.source_connection_env_type))) > 0
+  target_brs_vpe_active = var.create_target_cluster_brs_vpe_gateway && local.target_is_vpc && local.deploy_target_cluster
+}
+
 # Velero restores each PVC with the storageClassName it had on the SOURCE
 # cluster. In a Classic -> VPC migration those names (e.g. "ibmc-block-silver")
 # do not and cannot exist on the VPC target, which only has ibmc-vpc-block-*


### PR DESCRIPTION
### Description

This PR removes the VPE Gateway, S2S IAM authorization policy, and cross-account detection logic from the root module and moves them into the `backup-recovery-with-vpe-cross-account` example where they belong.

**Why this change is needed:**
The root module previously bundled VPE and S2S auth creation alongside the core BRS/DSC wiring. This tightly coupled concerns that are deployment-topology specific (cross-account vs same-account, VPE vs no VPE) to the reusable module itself, making the module heavier and harder to compose in simple single-account scenarios. VPE and S2S auth are infrastructure prerequisites that callers already own and should manage independently.

**What changed:**

- **Removed from `main.tf` (root module):**
  - `module.brs_s2s_auth` — S2S IAM authorization policy (cross-account VPEG → BRS)
  - `module.brs_vpe` — VPE Gateway module
  - `data.ibm_is_security_group.kube_vpeg_sg` — kube-vpegw SG lookup
  - `data.ibm_is_subnet.cluster_subnet` — VPC subnet auto-discovery data sources
  - `data.ibm_iam_auth_token.target_account` / `source_account` — JWT-based cross-account detection
  - All related locals: `is_cross_account`, `source_account_id`, `target_account_id`, `resolved_vpc_id`, `resolved_vpc_subnets`, `cluster_subnet_ids`, `brs_vpe_vpc_name`

- **Renamed provider alias in `main.tf`:** `ibm.cluster` → `ibm.source_account` across all cluster/VPC resources and the DSC worker pool, to align with the cross-account example's provider naming convention.

- **Refactored protection-source tree locals:** Renamed opaque `all_l1_*` / `all_l2_*` / `all_l3_*` identifiers to self-documenting names (`cluster_nodes`, `namespace_nodes`, `workload_nodes`, `cluster_protection_sources`, `namespace_protection_sources`, `workload_protection_sources`, `raw_envs`, `known_cluster_node_ids`, `known_namespace_parent_ids`, `should_filter_by_registered_cluster`). Behaviour is unchanged.

- **Added `terraform_data.check_existing_registration` to `helm_release.data_source_connector` `depends_on`** to ensure the pre-install conflict check always completes before the Helm install.

- **`examples/backup-recovery-with-vpe-cross-account`:** New complete example demonstrating VPE + S2S auth across two IBM Cloud accounts. Includes VPC, subnet, public gateway, IKS cluster creation in the source account, cross-account S2S IAM policy and VPEG in the target account, and a test workload (StatefulSet with 20 Gi VPC Block PVC).

- **`kubernetes_namespace_v1.dsc_namespace`:** Added `velero.io/exclude-from-backup=true` label so Velero excludes the DSC namespace from backups. Label is set on first apply; subsequent drift from OpenShift is ignored via `ignore_changes`.

**Dependencies:**
This PR must be merged after [#72](https://github.com/terraform-ibm-modules/terraform-ibm-iks-ocp-backup-recovery/pull/72) (which introduced `feat/s2s-vpeg`, the base branch for `example-validation`).

### Release required?

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Refactored root module to remove VPE Gateway, S2S IAM authorization policy, and cross-account detection logic. These concerns are now handled in the `backup-recovery-with-vpe-cross-account` example. The provider alias `ibm.cluster` has been renamed to `ibm.source_account` — update your provider block if you pass this alias explicitly. Added `velero.io/exclude-from-backup=true` label to the DSC namespace so Velero excludes it from backups. No changes to BRS instance provisioning, DSC deployment, source registration, or protection group behaviour.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.