### PR TITLE
fix: clamp zone index in DSC worker pool to prevent invalid index on destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,12 +134,18 @@ locals {
 
   # --- DSC worker pool zone math ---
   # Calculate workers per zone based on total replicas.
-  # zones_list is derived first so num_zones can be capped to the number of
-  # zones that actually exist on the cluster's default pool.  This prevents an
-  # "Invalid index" error during terraform refresh/destroy when the live cluster
-  # returns fewer zones than dsc_worker_pool_zones requested at apply time.
+  #
+  # num_zones MUST derive from var.dsc_worker_pool_zones only (a static input)
+  # so that the worker pool `count` is known at plan time.  Using a
+  # data-source-derived length here causes "Invalid count argument" errors.
+  #
+  # To guard against the "Invalid index" crash on refresh/destroy — which
+  # occurs when worker_pools[0] resolves to a single-zone DSC pool instead of
+  # the original default pool — the zone index is clamped inside the resource
+  # block using min(count.index, length(zones_list)-1).  This keeps count
+  # static while preventing an out-of-bounds access on zones_list.
   zones_list    = local.is_vpc && var.create_dsc_worker_pool ? [for zone in data.ibm_container_vpc_worker_pool.pool[0].zones : zone] : []
-  num_zones     = local.is_vpc && var.create_dsc_worker_pool ? min(var.dsc_worker_pool_zones, length(local.zones_list)) : 0
+  num_zones     = local.is_vpc && var.create_dsc_worker_pool ? var.dsc_worker_pool_zones : 0
   base_workers  = local.num_zones > 0 ? floor(var.dsc_replicas / local.num_zones) : 0
   extra_workers = local.num_zones > 0 ? var.dsc_replicas % local.num_zones : 0
 
@@ -592,8 +598,8 @@ resource "ibm_container_vpc_worker_pool" "data_source_connector" {
   resource_group_id = var.cluster_resource_group_id
 
   zones {
-    name      = local.zones_list[count.index].name
-    subnet_id = local.zones_list[count.index].subnet_id
+    name      = local.zones_list[min(count.index, length(local.zones_list) - 1)].name
+    subnet_id = local.zones_list[min(count.index, length(local.zones_list) - 1)].subnet_id
   }
 
   labels = {

--- a/main.tf
+++ b/main.tf
@@ -134,18 +134,8 @@ locals {
 
   # --- DSC worker pool zone math ---
   # Calculate workers per zone based on total replicas.
-  #
-  # num_zones MUST derive from var.dsc_worker_pool_zones only (a static input)
-  # so that the worker pool `count` is known at plan time.  Using a
-  # data-source-derived length here causes "Invalid count argument" errors.
-  #
-  # To guard against the "Invalid index" crash on refresh/destroy — which
-  # occurs when worker_pools[0] resolves to a single-zone DSC pool instead of
-  # the original default pool — the zone index is clamped inside the resource
-  # block using min(count.index, length(zones_list)-1).  This keeps count
-  # static while preventing an out-of-bounds access on zones_list.
-  zones_list    = local.is_vpc && var.create_dsc_worker_pool ? [for zone in data.ibm_container_vpc_worker_pool.pool[0].zones : zone] : []
   num_zones     = local.is_vpc && var.create_dsc_worker_pool ? var.dsc_worker_pool_zones : 0
+  zones_list    = local.is_vpc && var.create_dsc_worker_pool ? [for zone in data.ibm_container_vpc_worker_pool.pool[0].zones : zone] : []
   base_workers  = local.num_zones > 0 ? floor(var.dsc_replicas / local.num_zones) : 0
   extra_workers = local.num_zones > 0 ? var.dsc_replicas % local.num_zones : 0
 

--- a/main.tf
+++ b/main.tf
@@ -134,8 +134,12 @@ locals {
 
   # --- DSC worker pool zone math ---
   # Calculate workers per zone based on total replicas.
-  num_zones     = local.is_vpc && var.create_dsc_worker_pool ? var.dsc_worker_pool_zones : 0
+  # zones_list is derived first so num_zones can be capped to the number of
+  # zones that actually exist on the cluster's default pool.  This prevents an
+  # "Invalid index" error during terraform refresh/destroy when the live cluster
+  # returns fewer zones than dsc_worker_pool_zones requested at apply time.
   zones_list    = local.is_vpc && var.create_dsc_worker_pool ? [for zone in data.ibm_container_vpc_worker_pool.pool[0].zones : zone] : []
+  num_zones     = local.is_vpc && var.create_dsc_worker_pool ? min(var.dsc_worker_pool_zones, length(local.zones_list)) : 0
   base_workers  = local.num_zones > 0 ? floor(var.dsc_replicas / local.num_zones) : 0
   extra_workers = local.num_zones > 0 ? var.dsc_replicas % local.num_zones : 0
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -38,7 +38,6 @@ var includeFiletypes = []string{".tf", ".yaml", ".py", ".tpl", ".md", ".sh"}
 // and can push total wall-clock time over the GitHub Actions job limit.
 var validRegions = []string{
 	"eu-es",
-	"eu-gb",
 	"eu-de",
 	"br-sao",
 	"ca-tor",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -37,12 +37,9 @@ var includeFiletypes = []string{".tf", ".yaml", ".py", ".tpl", ".md", ".sh"}
 // to minimise same-region collisions, which slow down IKS cluster provisioning
 // and can push total wall-clock time over the GitHub Actions job limit.
 var validRegions = []string{
-	"us-south",
-	"us-east",
 	"eu-es",
 	"eu-gb",
 	"eu-de",
-	"au-syd",
 	"br-sao",
 	"ca-tor",
 	"jp-osa",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testschematic"
 )
 
-const resourceGroup = "BRT-General-testing"
-const existing_brs_instance_crn = "crn:v1:bluemix:public:backup-recovery:au-syd:a/7d8f9e928b9d6c2dfa06475946765e01:4dde55c7-e8a8-48c8-b431-c226f75090f7::"
+const resourceGroup = "E2E Test"
+const existing_brs_instance_crn = "crn:v1:bluemix:public:backup-recovery:au-syd:a/0f628e88c6594675bbefa097a63b9293:e0c89382-56e2-453f-906e-a2b91a60f19a::"
 const fullyConfigurableTerraformDir = "solutions/fully-configurable"
 const iksExampleDir = "examples/kubernetes"
 const ocpExampleDir = "examples/openshift"

--- a/tests/resources/main.tf
+++ b/tests/resources/main.tf
@@ -43,6 +43,17 @@ resource "ibm_is_subnet" "subnet_zone_1" {
 }
 
 ########################################################################################################################
+# Wait for IAM to propagate subnet visibility before creating the cluster.
+# Without this, the container service sometimes rejects the token as not
+# authorised to view the subnet that was just created in the same apply.
+########################################################################################################################
+
+resource "time_sleep" "wait_for_subnet" {
+  depends_on      = [ibm_is_subnet.subnet_zone_1]
+  create_duration = "30s"
+}
+
+########################################################################################################################
 # OCP VPC cluster (single zone)
 ########################################################################################################################
 
@@ -83,4 +94,5 @@ module "ocp_base" {
   vpc_subnets          = local.cluster_vpc_subnets
   worker_pools         = local.worker_pools
   access_tags          = []
+  depends_on           = [time_sleep.wait_for_subnet]
 }

--- a/tests/resources/version.tf
+++ b/tests/resources/version.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = ">= 1.88.3"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1"
+    }
   }
 }


### PR DESCRIPTION
### Description

During `terraform destroy`, the refresh phase re-reads the cluster's default worker pool (`worker_pools[0]`) to build `zones_list`. In some cases — particularly after the DSC worker pools are created — the IBM Cloud API returns a DSC pool as `worker_pools[0]` instead of the original default pool. Since DSC pools are single-zone, `zones_list` ends up with only 1 element, while the Terraform state still has 2 `data_source_connector` resources (created with `dsc_worker_pool_zones = 2`). This causes an **"Invalid index"** error during refresh because `zones_list[1]` is out of bounds, blocking the destroy entirely.

**Fix:** The zone `name` and `subnet_id` lookups inside the `ibm_container_vpc_worker_pool` resource block now use `min(count.index, length(local.zones_list) - 1)` instead of `count.index` directly. This clamps the index to the last available zone when the live cluster returns fewer zones than expected, preventing the out-of-bounds crash on destroy.

`count` continues to use the static `var.dsc_worker_pool_zones` so it remains known at plan time — avoiding the `"Invalid count argument"` error that occurs when `count` depends on a data source.

Fixes: https://ibm-iaas.atlassian.net/browse/BAAS-8407

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixed an "Invalid index" error during `terraform destroy` (and `terraform refresh`) that occurred when `dsc_worker_pool_zones > 1`. The IBM Cloud API could return a DSC worker pool as the first pool (`worker_pools[0]`) after apply, causing `zones_list` to have fewer entries than expected and crashing with an index out-of-bounds error. The zone index in the `ibm_container_vpc_worker_pool` resource is now clamped with `min(count.index, length(zones_list) - 1)` to prevent this. No behaviour change for deployments where the cluster zone count is consistent between apply and destroy.

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
